### PR TITLE
Added support to pass the NTP version

### DIFF
--- a/ntpserver.py
+++ b/ntpserver.py
@@ -272,7 +272,7 @@ class WorkThread(threading.Thread):
                 recvPacket = NTPPacket()
                 recvPacket.from_data(data)
                 timeStamp_high,timeStamp_low = recvPacket.GetTxTimeStamp()
-                sendPacket = NTPPacket(version=3,mode=4)
+                sendPacket = NTPPacket(version=recvPacket.version,mode=4)
                 sendPacket.stratum = 2
                 sendPacket.poll = 10
                 '''


### PR DESCRIPTION
Add support to pass the NTP version from the request message to the response message.

We tested this against two different legacy RTUs that where one support version 4 and the other supported version 3. It worked find for the version 3 RTU but failed for the version 4. Adding this line allowed it to work for both. 
This NTP Server is the first software based NTP server we have found that could set the time on these legacy RTUs.